### PR TITLE
Set version.m4 to 2.0.0

### DIFF
--- a/version.m4
+++ b/version.m4
@@ -1,2 +1,2 @@
 m4_define([_NAME_],[EosSdk])
-m4_define([_VERSION_],[1.13.0])
+m4_define([_VERSION_],[2.0.0])


### PR DESCRIPTION
Set version to 2.0.0 for libeos stub library.

@avi-kumar -- this one-liner let me build my app properly. I'm sure there's probably more upstream syncs necessary :)

Fixes #43 