### PR TITLE
Create GO_SRCDIR before linking into it

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -62,6 +62,7 @@ set -x
 STUBS_DIR=$PWD
 GO_SRCDIR="$STUBS_DIR/go/src/eossdk"
 rm -f "$GO_SRCDIR/eos"
+mkdir -p "$GO_SRCDIR"
 ln -s "$STUBS_DIR/eos" "$GO_SRCDIR/"
 
 exec make "$@"


### PR DESCRIPTION
Fixes https://github.com/aristanetworks/EosSdk/issues/56

Simply create the folder before linking into it.

```
2020-11-19T20:24:04.970297571Z + STUBS_DIR=/build/arista/arista_sdk/EosSdk-2.15.0
2020-11-19T20:24:04.970338225Z + GO_SRCDIR=/build/arista/arista_sdk/EosSdk-2.15.0/go/src/eossdk
2020-11-19T20:24:04.970348573Z + rm -f /build/arista/arista_sdk/EosSdk-2.15.0/go/src/eossdk/eos
2020-11-19T20:24:04.970953037Z + ln -s /build/arista/arista_sdk/EosSdk-2.15.0/eos /build/arista/arista_sdk/EosSdk-2.15.0/go/src/eossdk/
2020-11-19T20:24:04.97145139Z ln: target '/build/arista/arista_sdk/EosSdk-2.15.0/go/src/eossdk/' is not a directory: No such file or directory
2020-11-19T20:24:04.971850971Z make: *** [/build/arista/arista_sdk/EosSdk-2.15.0/.libs/libeos.so] Error 1
2020-11-19T20:24:04.971868928Z device/arista_sdk/module.mk:6: recipe for target '/build/arista/arista_sdk/EosSdk-2.15.0/.libs/libeos.so' failed
2020-11-19T20:24:04.971870599Z make: *** Waiting for unfinished jobs....
```