### PR TITLE
Update python eossdk_utils.py debug_fn to return function values

### DIFF
--- a/examples/eossdk_utils.py
+++ b/examples/eossdk_utils.py
@@ -34,7 +34,7 @@ def debug_fn(func):
    @wraps(func)
    def wrapped_fn(*args, **kwargs):
       try:
-         func(*args, **kwargs)
+         return func(*args, **kwargs)
       except Exception as e:
          traceback.print_exc()
          if sys.stdout.isatty():


### PR DESCRIPTION
A @debug_fn wrapped function should also return the result of the function it executes, otherwise it returns None.

```
class SomeAgent(eossdk.IntfHandler):
    def __init__(self, sdk):
        self.intf_mgr = sdk.get_intf_mgr()
        self.tracer = eossdk.Tracer('debug_fn_sample')
        eossdk.IntfHandler.__init__(self, self.intf_mgr)

    @debug_fn
    def get_value(self):
        return 'foo'

    def on_oper_status(self, intf_id_t, oper_status_t):
        value = self.get_value()  # returns None.
        assert value == 'foo'
```